### PR TITLE
validation for static overwrite with filter

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -373,10 +373,7 @@ class UnboundPredicate(Generic[L], Unbound[BooleanExpression], BooleanExpression
 class UnaryPredicate(UnboundPredicate[Any], ABC):
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate[Any]:
         bound_term = self.term.bind(schema, case_sensitive)
-        print(f"{bound_term=}")
-        res = self.as_bound(bound_term)
-        print(f"{res=}")
-        return res
+        return self.as_bound(bound_term)
 
     def __repr__(self) -> str:
         """Return the string representation of the UnaryPredicate class."""

--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -383,6 +383,10 @@ class UnaryPredicate(UnboundPredicate[Any], ABC):
     @abstractmethod
     def as_bound(self) -> Type[BoundUnaryPredicate[Any]]: ...
 
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+
 
 class BoundUnaryPredicate(BoundPredicate[L], ABC):
     def __repr__(self) -> str:
@@ -697,6 +701,9 @@ class LiteralPredicate(UnboundPredicate[L], ABC):
     @property
     @abstractmethod
     def as_bound(self) -> Type[BoundLiteralPredicate[L]]: ...
+
+    def __hash__(self) -> int:
+        return hash(str(self))
 
 
 class BoundLiteralPredicate(BoundPredicate[L], ABC):

--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -373,7 +373,10 @@ class UnboundPredicate(Generic[L], Unbound[BooleanExpression], BooleanExpression
 class UnaryPredicate(UnboundPredicate[Any], ABC):
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate[Any]:
         bound_term = self.term.bind(schema, case_sensitive)
-        return self.as_bound(bound_term)
+        print(f"{bound_term=}")
+        res = self.as_bound(bound_term)
+        print(f"{res=}")
+        return res
 
     def __repr__(self) -> str:
         """Return the string representation of the UnaryPredicate class."""
@@ -384,8 +387,8 @@ class UnaryPredicate(UnboundPredicate[Any], ABC):
     def as_bound(self) -> Type[BoundUnaryPredicate[Any]]: ...
 
     def __hash__(self) -> int:
+        """Return hash value of the UnaryPredicate class."""
         return hash(str(self))
-
 
 
 class BoundUnaryPredicate(BoundPredicate[L], ABC):
@@ -415,6 +418,10 @@ class BoundIsNull(BoundUnaryPredicate[L]):
     @property
     def as_unbound(self) -> Type[IsNull]:
         return IsNull
+
+    def __hash__(self) -> int:
+        """Return hash value of the BoundIsNull class."""
+        return hash(str(self))
 
 
 class BoundNotNull(BoundUnaryPredicate[L]):
@@ -703,6 +710,7 @@ class LiteralPredicate(UnboundPredicate[L], ABC):
     def as_bound(self) -> Type[BoundLiteralPredicate[L]]: ...
 
     def __hash__(self) -> int:
+        """Return hash value of the UnaryPredicate class."""
         return hash(str(self))
 
 
@@ -737,6 +745,10 @@ class BoundEqualTo(BoundLiteralPredicate[L]):
     @property
     def as_unbound(self) -> Type[EqualTo[L]]:
         return EqualTo
+
+    def __hash__(self) -> int:
+        """Return hash value of the BoundEqualTo class."""
+        return hash(str(self))
 
 
 class BoundNotEqualTo(BoundLiteralPredicate[L]):

--- a/pyiceberg/table/__init__.py
+++ b/pyiceberg/table/__init__.py
@@ -296,7 +296,10 @@ def _check_schema_with_filter_predicates(
 def _check_schema(table_schema: Schema, other_schema: "pa.Schema") -> None:
     task_schema = _arrow_schema_to_iceberg_schema_with_field_ids(table_schema, other_schema)
 
-    if table_schema.as_struct() != task_schema.as_struct():
+    sorted_table_schema = Schema(*sorted(table_schema.fields, key=lambda field: field.field_id))
+    sorted_task_schema = Schema(*sorted(task_schema.fields, key=lambda field: field.field_id))
+
+    if sorted_table_schema.as_struct() != sorted_task_schema.as_struct():
         from rich.console import Console
         from rich.table import Table as RichTable
 

--- a/tests/integration/test_partitioned_writes.py
+++ b/tests/integration/test_partitioned_writes.py
@@ -446,7 +446,7 @@ def test_summaries_with_null(spark: SparkSession, session_catalog: Catalog, arro
     tbl.overwrite(arrow_table_with_null)
     tbl.append(arrow_table_with_null)
     valid_arrow_table_with_null_to_overwrite = arrow_table_with_null.drop(['int'])
-    tbl.overwrite(valid_arrow_table_with_null_to_overwrite,  overwrite_filter="int=1")
+    tbl.overwrite(valid_arrow_table_with_null_to_overwrite, overwrite_filter="int=1")
 
     rows = spark.sql(
         f"""
@@ -550,7 +550,7 @@ def test_data_files_with_table_partitioned_with_null(
     tbl.append(arrow_table_with_null)
 
     valid_arrow_table_with_null_to_overwrite = arrow_table_with_null.drop(['int'])
-    tbl.overwrite(valid_arrow_table_with_null_to_overwrite,  overwrite_filter="int=1")
+    tbl.overwrite(valid_arrow_table_with_null_to_overwrite, overwrite_filter="int=1")
 
     # first append links to 1 manifest file (M1)
     # second append's manifest list links to  2 manifest files (M1, M2)
@@ -672,24 +672,19 @@ def test_query_filter_after_append_overwrite_table_with_expr(
         properties={'format-version': '1'},
     )
 
-    
-    for i in range(3):
+    for _ in range(3):
         tbl.append(arrow_table_with_null)
-        print("this is ", i)
         spark.sql(f"refresh table {identifier}")
         spark.sql(f"select file_path from {identifier}.files").show(20, False)
         spark.sql(f"select * from {identifier}").show(20, False)
-
 
     valid_arrow_table_with_null_to_overwrite = arrow_table_with_null.drop([part_col])
     tbl.overwrite(valid_arrow_table_with_null_to_overwrite, expr)
 
     iceberg_table = session_catalog.load_table(identifier=identifier)
     spark.sql(f"refresh table {identifier}")
-    print("this is 3")
     spark.sql(f"select file_path from {identifier}.files").show(20, False)
     spark.sql(f"select * from {identifier}").show(20, False)
-    
+
     assert iceberg_table.scan().to_arrow().num_rows == 9
     assert iceberg_table.scan(row_filter=expr).to_arrow().num_rows == 3
-    

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -1029,20 +1029,17 @@ def test_correct_schema() -> None:
     assert "Snapshot not found: -1" in str(exc_info.value)
 
 
-def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_schema_fields_in_filter() -> None:
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
-    )
+def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_schema_fields_in_filter(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = EqualTo(Reference("not a field"), "hello")
     partition_spec = PartitionSpec(
         PartitionField(source_id=1, field_id=1001, transform=IdentityTransform(), name="test_part_col")
     )
     with pytest.raises(ValueError, match="Could not find field with name not a field, case_sensitive=True"):
-        _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
+        _bind_and_validate_static_overwrite_filter_predicate(
+            unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
+        )
 
 
 def test__fill_in_df(table_schema_simple: Schema) -> None:
@@ -1069,14 +1066,9 @@ def test__fill_in_df(table_schema_simple: Schema) -> None:
     assert filled_df == expected
 
 
-def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_part_fields_in_filter() -> None:
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
-    )
+def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_part_fields_in_filter(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = EqualTo(Reference("foo"), "hello")
     partition_spec = PartitionSpec(PartitionField(source_id=2, field_id=1001, transform=IdentityTransform(), name="bar"))
     import re
@@ -1087,17 +1079,14 @@ def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_part_
             "Get 0 partition fields from filter predicate EqualTo(term=Reference(name='foo'), literal=literal('hello')), expecting 1."
         ),
     ):
-        _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
+        _bind_and_validate_static_overwrite_filter_predicate(
+            unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
+        )
 
 
-def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_identity_transorm_filter() -> None:
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
-    )
+def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_identity_transorm_filter(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = EqualTo(Reference("foo"), "hello")
     partition_spec = PartitionSpec(
         PartitionField(source_id=2, field_id=1001, transform=IdentityTransform(), name="bar"),
@@ -1108,53 +1097,42 @@ def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_ident
         ValueError,
         match="static overwrite partition filter can only apply to partition fields which are without hidden transform, but get.*",
     ):
-        _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
+        _bind_and_validate_static_overwrite_filter_predicate(
+            unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
+        )
 
 
-def test__bind_and_validate_static_overwrite_filter_predicate_succeeds_on_an_identity_transform_field_although_table_has_other_hidden_partition_fields() -> (
-    None
-):
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
-    )
+def test__bind_and_validate_static_overwrite_filter_predicate_succeeds_on_an_identity_transform_field_although_table_has_other_hidden_partition_fields(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = EqualTo(Reference("bar"), 3)
     partition_spec = PartitionSpec(
         PartitionField(source_id=2, field_id=1001, transform=IdentityTransform(), name="bar"),
         PartitionField(source_id=1, field_id=1002, transform=TruncateTransform(2), name="foo_trunc"),
     )
 
-    _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
-
-
-def test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind() -> None:
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
+    _bind_and_validate_static_overwrite_filter_predicate(
+        unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
     )
+
+
+def test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_to_incompatible_predicate_value(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = EqualTo(Reference("bar"), "an incompatible type")
     partition_spec = PartitionSpec(
         PartitionField(source_id=2, field_id=1001, transform=IdentityTransform(), name="bar"),
         PartitionField(source_id=1, field_id=1002, transform=TruncateTransform(2), name="foo_trunc"),
     )
     with pytest.raises(ValueError, match="Could not convert an incompatible type into a int"):
-        _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
+        _bind_and_validate_static_overwrite_filter_predicate(
+            unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
+        )
 
 
-def test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_to_non_nullable() -> None:
-    test_schema = Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
-        NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
-        NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
-        schema_id=1,
-        identifier_field_ids=[2],
-    )
+def test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_to_non_nullable(
+    iceberg_schema_simple: Schema,
+) -> None:
     pred = IsNull(Reference("bar"))
     partition_spec = PartitionSpec(
         PartitionField(source_id=3, field_id=1001, transform=IdentityTransform(), name="baz"),
@@ -1166,7 +1144,9 @@ def test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_
             "Static overwriting with part of the explicit partition filter not meaningful (specifing a non-nullable partition field to be null)"
         ),
     ):
-        _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
+        _bind_and_validate_static_overwrite_filter_predicate(
+            unbound_expr=pred, table_schema=iceberg_schema_simple, spec=partition_spec
+        )
 
 
 def test__check_schema_with_filter_succeed(iceberg_schema_simple: Schema) -> None:
@@ -1421,14 +1401,14 @@ def test_check_schema_succeed(table_schema_simple: Schema) -> None:
     _check_schema(table_schema_simple, other_schema)
 
 
-def test_schema_succeed_on_pyarrow_table_reversed_column_order(table_schema_simple: Schema) -> None:
+def test_schema_succeed_on_pyarrow_table_reversed_column_order(iceberg_schema_simple: Schema) -> None:
     other_schema = pa.schema((
         pa.field("baz", pa.bool_(), nullable=True),
         pa.field("bar", pa.int32(), nullable=False),
         pa.field("foo", pa.string(), nullable=True),
     ))
 
-    _check_schema(table_schema_simple, other_schema)
+    _check_schema(iceberg_schema_simple, other_schema)
 
 
 def test_schema_mismatch_additional_field(table_schema_simple: Schema) -> None:

--- a/tests/table/test_init.py
+++ b/tests/table/test_init.py
@@ -74,6 +74,7 @@ from pyiceberg.table import (
     _apply_table_update,
     _bind_and_validate_static_overwrite_filter_predicate,
     _check_schema,
+    _check_schema_with_filter_predicates,
     _fill_in_df,
     _match_deletes_to_data_file,
     _TableMetadataUpdateContext,
@@ -1028,7 +1029,6 @@ def test_correct_schema() -> None:
     assert "Snapshot not found: -1" in str(exc_info.value)
 
 
-# _bind_and_validate_static_overwrite_filter_predicate
 def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_schema_fields_in_filter() -> None:
     test_schema = Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
@@ -1043,21 +1043,6 @@ def test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_schem
     )
     with pytest.raises(ValueError, match="Could not find field with name not a field, case_sensitive=True"):
         _bind_and_validate_static_overwrite_filter_predicate(unbound_expr=pred, table_schema=test_schema, spec=partition_spec)
-
-
-# @pytest.mark.zy
-# def test_mine(table_schema_simple) -> None:
-#     pred = IsNull("bar")
-#     print("xxxx!", pred.term)
-#     pred.bind(table_schema_simple)
-
-
-#     from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids, pyarrow_to_schema
-#     pa_table = pa.table(
-#         {"bar": [1, 2, 3], "foo": ["a", "b", "c"],  "baz": [True, False, None]},
-#     )
-#     name_mapping = table_schema_simple.name_mapping
-#     print("xxxx!", pyarrow_to_schema(pa_table.schema, name_mapping=name_mapping))
 
 
 def test__fill_in_df(table_schema_simple: Schema) -> None:
@@ -1195,7 +1180,7 @@ def test__check_schema_with_filter_succeed(iceberg_schema_simple: Schema) -> Non
     # upcast set[BoundLiteralPredicate[int]] to set[BoundPredicate[int]]
     # because _check_schema expects set[BoundPredicate[int]] and set is not covariant
     # (meaning although BoundLiteralPredicate is subclass of BoundPredicate, list[BoundLiteralPredicate] is not that of list[BoundPredicate])
-    _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+    _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 def test__check_schema_with_filter_succeed_on_pyarrow_table_with_random_column_order(iceberg_schema_simple: Schema) -> None:
@@ -1209,7 +1194,7 @@ def test__check_schema_with_filter_succeed_on_pyarrow_table_with_random_column_o
     # upcast set[BoundLiteralPredicate[int]] to set[BoundPredicate[int]]
     # because _check_schema expects set[BoundPredicate[int]] and set is not covariant
     # (meaning although BoundLiteralPredicate is subclass of BoundPredicate, list[BoundLiteralPredicate] is not that of list[BoundPredicate])
-    _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+    _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 def test__check_schema_with_filter_fails_on_missing_field(iceberg_schema_simple: Schema) -> None:
@@ -1235,7 +1220,7 @@ def test__check_schema_with_filter_fails_on_missing_field(iceberg_schema_simple:
 """
     )
     with pytest.raises(ValueError, match=expected):
-        _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+        _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 def test__check_schema_with_filter_fails_on_nullability_mismatch(iceberg_schema_simple: Schema) -> None:
@@ -1261,7 +1246,7 @@ def test__check_schema_with_filter_fails_on_nullability_mismatch(iceberg_schema_
 """
     )
     with pytest.raises(ValueError, match=expected):
-        _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+        _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 def test__check_schema_with_filter_fails_on_type_mismatch(iceberg_schema_simple: Schema) -> None:
@@ -1287,7 +1272,7 @@ def test__check_schema_with_filter_fails_on_type_mismatch(iceberg_schema_simple:
 """
     )
     with pytest.raises(ValueError, match=expected):
-        _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+        _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 def test__check_schema_with_filter_fails_due_to_filter_and_dataframe_holding_same_field(iceberg_schema_simple: Schema) -> None:
@@ -1310,7 +1295,7 @@ def test__check_schema_with_filter_fails_due_to_filter_and_dataframe_holding_sam
 """
     )
     with pytest.raises(ValueError, match=expected):
-        _check_schema(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
+        _check_schema_with_filter_predicates(iceberg_schema_simple, other_schema, filter_predicates=filter_predicates)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Section 1: Background** 
When we are doing a static overwrite, we could choose to overwrite the full table or overwrite some partitions of the table. 

Example spark sql counterpart in [iceberg spark static overwrite](https://iceberg.apache.org/docs/latest/spark-writes/#static-overwrite) for full table overwrite is 
```
INSERT OVERWRITE prod.my_app.logs
SELECT uuid, first(level), first(ts), first(message)
FROM prod.my_app.logs
WHERE level = 'INFO'
GROUP BY uuid
```
And example spark sql counterpart  for specified partition overwrite  is
```
INSERT OVERWRITE prod.my_app.logs
SELECT uuid, first(level), first(ts), first(message)
PARTITION (level = 'INFO')
FROM prod.my_app.logs
WHERE level = 'INFO'
GROUP BY uuid
```
**Section 2: Goal of the Pull Request**
When we overwrite the table, we could provide an expression as overwrite_filter in accord with these 2 cases. The filter expression should conform to certain rules such as it has to be on a partition column that does not use hidden partitioning and the fields in the filter have to be in accord with the input arrow table in a certain way so that the new partition has the partition value auto-filled in accord with the removed partition. This pull request aims at logics of:

1. Validate the filter and the filter-arrowtable relationship against the iceberg table schema.
2. Populate the arrow table for the partition column with specified partition value in the filter.

**Section 3: Rules and Test Cases**
1. **Rule :** The expression could only use **IsNull** or **EqualTo** as building blocks and concatenated by **And**
     **Tests :** `test__validate_static_overwrite_filter_expr_type` parametrize 1-8

2. **Rule :** The building block predicates (IsNull and EqualTo) should not have conflicting values.
     **Tests :** `test__validate_static_overwrite_filter_expr_type` parametrize 9-11

3. **Rule :** The terms (fields) should refer to existing fields in the iceberg schema, and also the literal in the predicate (if any) should match the iceberg field type. These mean the expression could be bound with table schema successfully.
     **Tests :** 
`test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_schema_fields_in_filter`
`test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_to_incompatible_predicate_value`

4. **Rule :** If expression specifies a field which is required in iceberg schema, it should not be isnull in the expression.
     **Tests :** `test__bind_and_validate_static_overwrite_filter_predicate_fails_to_bind_due_to_non_nullable`

5. **Rule :** The fields in the expression should be within partition columns
     **Tests :** `test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_part_fields_in_filter`

6. **Rule :** The iceberg table fields specified in the expression could not have hidden partitioning, however, the non-specified fields could.
     **Tests :** 
`test__bind_and_validate_static_overwrite_filter_predicate_fails_on_non_identity_transorm_filter`  
`test__bind_and_validate_static_overwrite_filter_predicate_succeeds_on_an_identity_transform_field_although_table_has_other_hidden_partition_fields`

7. **Rule :** Three-way relationship between filter, arrow table and iceberg table schema
The fields in filter should not appear in the input arrow table. However when we remove these fields from iceberg schema, the remaining schema should match the arrow table schema precisely in terms of field names, nullability and type. 
![Three-set Venn diagram - Color (5)](https://github.com/jqin61/iceberg-python/assets/147659252/7a0d92f7-d2d7-4254-8cc8-8f2ce46accdc)

     **Tests :** 
case 2: `test__check_schema_with_filter_fails_on_missing_field` 
case 3: `test__check_schema_with_filter_fails_due_to_filter_and_dataframe_holding_same_field`
case 4: `test__check_schema_with_filter_fails_on_nullability_mismatch`
case 4: `test__check_schema_with_filter_fails_on_type_mismatch`
case 5: `test__check_schema_with_filter_succeed`
case 5: `test__check_schema_with_filter_succeed_on_pyarrow_table_with_random_column_order` for this change https://github.com/jqin61/iceberg-python/pull/4/files#diff-8d5e63f2a87ead8cebe2fd8ac5dcf2198d229f01e16bb9e06e21f7277c328abdR1739


**Section 4: Flow and Scedo Code Logics**
1. Entire Flow:
![Static Overwrite Filter Validation Flow](https://github.com/jqin61/iceberg-python/assets/147659252/e3282827-30a9-4522-a798-c91c9267e927)

2. Rule 7 Elaboration:
![Flowchart](https://github.com/jqin61/iceberg-python/assets/147659252/4fe4f0fa-963e-440d-adeb-e7865e5378bd)

**Section 5: Rule Necessity Justification - Spark Counterparts**
To better understand these rules, let us provide spark static overwrite crash counterparts. For which, we have following set up:
```
# Create Spark Dataframe
from pyspark.sql.types import StructType, StructField, StringType, LongType
data_multicols = [(2, "Flamingo", "red"), (4, "Horse", "white"), (4, "Pig", "pink")]
schema = StructType([
    StructField("n_legs", LongType(), nullable=True),
    StructField("animals", StringType(), nullable=True),
    StructField("color", StringType(), nullable=True)  # Mark as non-nullable
])
df_multicols = spark.createDataFrame(data_multicols, schema)

# Create Iceberg Table
create_sql = """CREATE TABLE lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols ( 
    n_legs bigint, 
    animals string,
    color string) 
USING iceberg
PARTITIONED BY (n_legs, color)

"""
spark.sql(create_sql)

# Insert Initial data
df_multicols.createOrReplaceTempView("tmp_view")
sql_cmd = f"""INSERT INTO
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    SELECT * FROM  tmp_view
    """
spark.sql(sql_cmd)
```

this gives such table schema:

|      col_name|data_type|comment|
|--------------|---------|-------|
|        n_legs|   bigint|       |
|       animals|   string|       |
|         color|   string|       |

| Partitioning|         |       |
|--------------|---------|-------|
|        Part 0|   n_legs|       |
|        Part 1|    color|       |

with such data:
|n_legs| animals|color|
|------|--------|-----|
|     2|Flamingo|  red|
|     4|   Horse|white|
|     4|     Pig| pink|


Now let us check the rules
**Rule 1. The expression could only use **IsNull** or **EqualTo** as building blocks and concatenated by **And**.**
For example:
```
And(EqualTo(Reference("foo"), "hello"), And(IsNull(Reference("baz")), EqualTo(Reference("boo"), "hello")))
```
or
```"foo = 'hello' AND (baz IS NULL AND boo = 'hello') ```

Spark counterpart example:
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (n_legs > 2)
    SELECT color,animals FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives:
```
mismatched input '>' expecting {')', ','}(line 3, pos 22)

== SQL ==
INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (n_legs > 2)
----------------------^^^
    SELECT color,animals FROM  tmp_view
```
Other predicates of 'in', '!=', etc and other expression such as 'Or' give similar errors.

**Rule 2. The building block predicates (IsNull and EqualTo) should not have conflicting values. **
This means 
```
And(EqualTo(Reference("foo"), "hello"), EqualTo(Reference("foo"), "bye"))
```
and
```
And(EqualTo(Reference("foo"), "hello"), IsNull(Reference("foo"))
```
are not allowed.

However,
```
And(EqualTo(Reference("foo"), "hello"), EqualTo(Reference("foo"), "hello"))
```
is allowed and shall be deduplicated.

Spark counterpart example:
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (color='red', color='green')
    SELECT animals,n_legs FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives
```
ParseException: 
Found duplicate keys 'color'.(line 3, pos 4)

== SQL ==
INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (color='red', color='green')
----^^^
    SELECT animals,n_legs FROM  tmp_view
```

**Rule 3. The terms (fields) should refer to existing fields in the iceberg schema, and also the literal in the predicate (if any) should match the iceberg field type. These mean the expression could be bound with table schema successfully.**

Spark counterpart example:
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (not_a_field='red')
    SELECT animals,n_legs FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives:
```
AnalysisException: PARTITION clause cannot contain a non-partition column name: not_a_field
```
**Rule 4. If expression specifies a field which is required in iceberg schema, it should not be isnull in the expression.**

Spark counterpart example:
```
# Create Spark Dataframe with non-nullable column
from pyspark.sql.types import StructType, StructField, StringType, LongType
data_multicols = [(2, "Flamingo", "red"), (4, "Horse", "white"), (4, "Pig", "pink")]
schema = StructType([
    StructField("n_legs", LongType(), nullable=True),
    StructField("animals", StringType(), nullable=True),
    StructField("color", StringType(), nullable=False)  # Mark as non-nullable
])
df_multicols = spark.createDataFrame(data_multicols, schema)

# Create Iceberg Table with non-nullable column
create_sql = """CREATE TABLE lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols ( 
    n_legs bigint, 
    animals string,
    color string not NULL) 
USING iceberg
PARTITIONED BY (n_legs, color)

"""
spark.sql(create_sql)

# Insert Initial data
df_multicols.createOrReplaceTempView("tmp_view")
sql_cmd = f"""INSERT INTO
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    SELECT * FROM  tmp_view
    """
spark.sql(sql_cmd)

sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (color=null)
    SELECT animals, n_legs FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives:
```
AnalysisException: Cannot write incompatible data to table 'lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols':
- Cannot safely cast 'n_legs': string to bigint
- Cannot write nullable values to non-null column 'color'
```

**Rule 5. The fields in the expression should be within partition columns**
Spark counterpart example:
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (animals='pig')
    SELECT n_legs, color FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives:
```
AnalysisException: PARTITION clause cannot contain a non-partition column name: animals
```
**Rule 6. The iceberg table fields specified in the expression could not have hidden partitioning, however, the non-specified fields could.**

Spark counterpart example:
```
create_sql = """CREATE TABLE lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols_with_transforms ( 
    n_legs bigint, 
    animals string,
    color string
) 
USING iceberg
PARTITIONED BY (n_legs, truncate(color, 1))
"""
spark.sql(create_sql)

sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols_with_transforms
    PARTITION (color='red')
    SELECT n_legs, animals FROM  tmp_view
    """
spark.sql(sql_cmd)

```
gives:
```
AnalysisException: PARTITION clause cannot contain a non-partition column name: color
```

However, if we specify the other partition column with identity transform, it works:
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols_with_transforms
    PARTITION (n_legs=1)
    SELECT color, animals FROM  tmp_view
    """
spark.sql(sql_cmd)
```

**Rule 7. Three-way relationship between filter, arrow table and iceberg table schema**

**Rule 7 Case 1** 
```
from pyspark.sql.types import StructType, StructField, StringType, LongType
data_multicols_extra_col = [(2, "Flamingo", "red", "dummy"), (4, "Horse", "white", "dummy"), (4, "Pig", "pink", "dummy")]
schema_extra_col = StructType([
    StructField("n_legs", LongType(), nullable=True),
    StructField("animals", StringType(), nullable=True),
    StructField("color", StringType(), nullable=True),
    StructField("extra_col", StringType(), nullable=True)  
])
df_multicols_extra_col = spark.createDataFrame(data_multicols_extra_col, schema_extra_col)
df_multicols_extra_col.createOrReplaceTempView("tmp_view_extra_col")
```
gives:
```
AnalysisException: Cannot write to 'lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols', too many data columns:
Table columns: 'n_legs', 'animals', 'color'
Data columns: 'n_legs', 'extra_col', 'color', 'animals'
```
**Rule 7 Case 2:**
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (n_legs = 2)
    SELECT animals FROM  tmp_view_extra_col
    """
spark.sql(sql_cmd)
```
gives
```
AnalysisException: Cannot write to 'lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols', not enough data columns:
Table columns: 'n_legs', 'animals', 'color'
Data columns: 'n_legs', 'animals'
```
**Rule 7 Case 3**
```
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (n_legs = 2)
    SELECT n_legs, color,animals FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives
```
AnalysisException: Cannot write to 'lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols', too many data columns:
Table columns: 'n_legs', 'animals', 'color'
Data columns: 'n_legs', 'n_legs', 'color', 'animals'
```

Rule 7 Case 4
```
from pyspark.sql.types import StructType, StructField, StringType, LongType
data_multicols_type_mismatch = [("dummy", "Flamingo", "red"), ("dummy", "Horse", "white"), ("dummy", "Pig", "pink")]
schema_type_mismatch = StructType([
    StructField("n_legs", StringType(), nullable=True),
    StructField("animals", StringType(), nullable=True),
    StructField("color", StringType(), nullable=True), 
])
df_multicols_type_mismatch = spark.createDataFrame(data_multicols_type_mismatch, schema_type_mismatch)
df_multicols_type_mismatch.createOrReplaceTempView("tmp_view_type_mismatch")

sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (color = 'red')
    SELECT n_legs, animals FROM  tmp_view_type_mismatch
    """
spark.sql(sql_cmd)
```
gives:
```
AnalysisException: Cannot write incompatible data to table 'lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols':
- Cannot safely cast 'n_legs': string to bigint
```

**Special Case Rule 7**
Please notice: Static overwrite with filter includes a complex scenario where filter has a subset of partition columns and the arrow table has the rest where full partition key is dynamically discovered for those non-specified partition fields.
```
# Static overwriter with subset of partition columns
sql_cmd = f"""INSERT OVERWRITE
    lacus.test.spark_staticoverwrite_partition_clause_and_data_reltship_multicols
    PARTITION (n_legs = 2)
    SELECT animals,color FROM  tmp_view
    """
spark.sql(sql_cmd)
```
gives:
![image](https://github.com/jqin61/iceberg-python/assets/147659252/ba29a8fe-a1d9-4fad-9f91-2eace91e26df)

For 3 way comparison, we need to print the mismatches clearly, sample of rule 7 printing:
https://github.com/jqin61/iceberg-python/pull/4/files#diff-f3df6bef7f6c6d2b05df9a09e0039ff4391ebb66725d41bb0f27f26bb2eb4047R1213

